### PR TITLE
Fix Ouranwood trees placing blocks in unloaded chunks (#13)

### DIFF
--- a/common/src/main/java/com/craisinlord/antarchy/content/worldgen/elythia/OuranwoodTreeFeature.java
+++ b/common/src/main/java/com/craisinlord/antarchy/content/worldgen/elythia/OuranwoodTreeFeature.java
@@ -11,9 +11,11 @@ import java.util.List;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.WorldGenRegion;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.LevelWriter;
 import net.minecraft.world.level.WorldGenLevel;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.CaveVines;
@@ -1476,6 +1478,26 @@ public class OuranwoodTreeFeature extends Feature<OuranwoodTreeConfiguration> {
     protected static boolean canGrowOn(WorldGenLevel level, BlockPos pos) {
         BlockState state = level.getBlockState(pos);
         return state.isFaceSturdy(level, pos, Direction.UP);
+    }
+
+    /**
+     * Guards every block write in this feature (and its subclasses) so the tree never places blocks in a chunk
+     * that lies outside the region currently being generated. Large canopies, branches and hanging vines can
+     * reach past the writable region; without this check those writes trip vanilla's
+     * "Detected setBlock in a far chunk" error spam and are silently dropped anyway (issue #13).
+     *
+     * <p>This overloads the inherited {@link Feature#setBlock(LevelWriter, BlockPos, BlockState)} for a
+     * {@link WorldGenLevel} argument, so the existing {@code setBlock(level, pos, state)} call sites route through
+     * it automatically. The cast to {@link LevelWriter} selects the inherited supermethod to perform the actual write.
+     */
+    protected void setBlock(WorldGenLevel level, BlockPos pos, BlockState state) {
+        if (canWriteAt(level, pos)) {
+            setBlock((LevelWriter) level, pos, state);
+        }
+    }
+
+    protected static boolean canWriteAt(WorldGenLevel level, BlockPos pos) {
+        return !(level instanceof WorldGenRegion region) || region.ensureCanWrite(pos);
     }
 
     protected static boolean canReplace(WorldGenLevel level, BlockPos pos) {


### PR DESCRIPTION
Fixes #13.

The log shows `Detected setBlock in a far chunk [...] currently generating: antarchy:ouranwood_trees` spamming during worldgen. That vanilla error fires in `WorldGenRegion.setBlock` whenever a feature writes to a `BlockPos` in a chunk outside the region currently being decorated. Ouranwood trees are large — tall trunk, wide canopy, long branches, hanging vines/acorns — so their outer writes routinely reach into a neighbouring, not-yet-writable chunk. Vanilla already drops those writes, but logs the error every time (the spam in the issue), and none of the feature's write sites were bounds-guarded.

The fix adds a `setBlock(WorldGenLevel, BlockPos, BlockState)` overload to `OuranwoodTreeFeature` that checks `WorldGenRegion.ensureCanWrite(pos)` before writing, delegating to the inherited `Feature.setBlock(LevelWriter, …)` via a cast (no recursion). Because `WorldGenLevel <: LevelWriter`, Java's overload resolution routes all existing `setBlock(level, pos, state)` call sites through the guard with **zero call-site changes**, and the `OuranwoodCocoonTreeFeature` subclass inherits it. This mirrors the pattern already used by this repo's Moleworm features (`region.ensureCanWrite(pos)`).

Behaviour for in-bounds blocks is unchanged; out-of-bounds writes — which vanilla was already discarding — are now skipped before the logging path, eliminating the spam and the wasted work.

The change is confined to the `common` module (no `fabric/` or `neoforge/` code touched). `./gradlew :common:build` / `:common:compileJava` succeed on JDK 21. I couldn't run the full multiloader build to green because a fresh clone is missing the `infinite_dimensions_jars/` proprietary deps that `fabric`/`neoforge` need — that's environmental, unrelated to this one-file common change.

Honest notes for your review:
- No live reproduction (no client/server world in my build env) — this is a reasoned, code-grounded fix verified by compile + bytecode-checking that all writes route through the guard. Please sanity-check in-game: generate fresh Elythia chunks and confirm the far-chunk spam is gone and boundary-adjacent Ouranwood trees look unchanged (they should, since vanilla already dropped those blocks).
- If you'd prefer trees that never clip at boundaries at all, that's a separate design change (shrinking the feature) beyond this bug.

*Disclosure: this contribution was made with AI assistance (Claude), reviewed and compile-verified by a human-directed process before submission.*
